### PR TITLE
Multiple commits from rwth-afu/UniPager:master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unipager"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unipager"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["Thomas Gatzweiler <mail@thomasgatzweiler.com>"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ cargo build --release
 ```
 The compiled binary will be created at `./target/release/unipager`.
 
-Be aware: Must be run with root privileges for GPIO access.
+Be aware: Must be run with root privileges for GPIO access. Secondly it may be required to disable Bluetooth on newer Raspberry Pi models to make the GPIO UART usable.
 
 ## Cross Compilation
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+unipager (1.0.3) unstable; urgency=medium
+
+  * Renames Raspager 1 to Raspager V2
+  * Updates server fallback list 
+  * Adds support for Orange Pi GPIO
+
+ -- RWTH Amateurfunkgruppe <rwth-afu@online.de>  Thu, 16 Aug 2018 12:00:00 +0200
+
 unipager (1.0.2) unstable; urgency=medium
 
   * Adds support for Raspberry Pi Zero W

--- a/src/frontend/assets/index.html
+++ b/src/frontend/assets/index.html
@@ -26,8 +26,8 @@
                 <select id="transmitter" v-model="config.transmitter">
                   <option>Dummy</option>
                   <option>Audio</option>
-                  <option value="Raspager">Raspager 1</option>
-                  <option value="Raspager2">Raspager 2</option>
+                  <option value="Raspager">Raspager V2</option>
+<!--                  <option value="Raspager2">Raspager 2</option>-->
                   <option>C9000</option>
                   <option>RFM69</option>
                 </select>


### PR DESCRIPTION
- Add hint for disabling Bluetooth (#122
- Renamed RaspagerV1 to V2, removed still not existing V2 (from HTML front-end config page)
- Bump version to 1.0.3